### PR TITLE
Fix For Missing JS Extension For Compiled Code

### DIFF
--- a/app/api/package.json
+++ b/app/api/package.json
@@ -1,13 +1,13 @@
 {
   "name": "api",
   "version": "1.0.0",
-  "main": "server.js",
+  "main": "dist/server.js",
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "tsx watch src/server.ts",
     "start": "npm run build && node dist/server.js",
-    "build": "npx prisma generate && npm run lint:check && tsc",
+    "build": "npx prisma generate && npm run lint:check && npx tsup src/server.ts --format esm --out-dir dist --target es2022 --sourcemap --clean --dts",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "lint:check": "eslint src/**/*.ts --max-warnings 0",
@@ -54,6 +54,7 @@
     "prisma": "^6.14.0",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
+    "tsup": "^8.5.0",
     "tsx": "^4.20.3",
     "typescript": "^5.9.2"
   }

--- a/app/api/prisma/schema.prisma
+++ b/app/api/prisma/schema.prisma
@@ -5,7 +5,7 @@ generator client {
 generator zod {
   provider = "prisma-zod-generator"
   output   = "../src/zod"
-}
+} 
 
 datasource db {
   provider  = "postgresql"


### PR DESCRIPTION
## Steps to Reproduce
1. Navigate to the `app/api/` directory.
2. Run `npm run start`.

## Expected Behavior
- The server starts successfully without errors (yayy)

## Actual Behavior
- Runtime throws: `Error [ERR_MODULE_NOT_FOUND]: Cannot find module`


## Cause
- When targeting **ES2022** with: "module": "ES2022", "moduleResolution": "bundler"

TypeScript **does not require explicit `.js` extensions at compile time**, so the project builds and dev works fine.  
- However, Node **requires `.js` extensions at runtime** for ES modules.  
- The problem is compounded by **Zod-generated files**, which reference other files without `.js` extensions — adding `.js` manually would be tedious and error-prone.

## Fix
- Introduced **tsup** in the build process (`npm run build`) to automatically append `.js` in the compiled output.  
- This ensures Node can resolve modules at runtime without modifying the original source or generated Zod files.

## Future Improvement
- Ideally, `prisma-zod-generator` could generate files with `.js` extensions in import statements, eliminating the need for post-build adjustments.
